### PR TITLE
momenjs js filename changed

### DIFF
--- a/flask_moment.py
+++ b/flask_moment.py
@@ -12,7 +12,7 @@ class _moment(object):
         elif version is not None:
             js_filename = 'moment-with-locales.min.js' if StrictVersion(version) >= StrictVersion('2.8.0') else 'moment-with-langs.min.js'
             js = '<script src="//cdnjs.cloudflare.com/ajax/libs/' \
-                 'moment.js/%s/moment-with-langs.min.js"></script>\n' % (version, js_filename)
+                 'moment.js/%s/%s"></script>\n' % (version, js_filename)
         return Markup('''%s<script>
 function flask_moment_render(elem) {
     $(elem).text(eval('moment("' + $(elem).data('timestamp') + '").' + $(elem).data('format') + ';'));

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -5,7 +5,7 @@ from distutils.version import StrictVersion
 
 class _moment(object):
     @staticmethod
-    def include_moment(version='2.5.1', local_js=None):
+    def include_moment(version='2.10.3', local_js=None):
         js = ''
         if local_js is not None:
             js = '<script src="%s"></script>\n' % local_js

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from jinja2 import Markup
 from flask import current_app
-
+from distutils.version import StrictVersion
 
 class _moment(object):
     @staticmethod
@@ -10,8 +10,9 @@ class _moment(object):
         if local_js is not None:
             js = '<script src="%s"></script>\n' % local_js
         elif version is not None:
+            js_filename = 'moment-with-locales.min.js' if StrictVersion(version) >= StrictVersion('2.8.0') else 'moment-with-langs.min.js'
             js = '<script src="//cdnjs.cloudflare.com/ajax/libs/' \
-                 'moment.js/%s/moment-with-langs.min.js"></script>\n' % version
+                 'moment.js/%s/moment-with-langs.min.js"></script>\n' % (version, js_filename)
         return Markup('''%s<script>
 function flask_moment_render(elem) {
     $(elem).text(eval('moment("' + $(elem).data('timestamp') + '").' + $(elem).data('format') + ';'));


### PR DESCRIPTION
The js file name changed from moment-with-langs.min.js to moment-with-locales.min.js since 2.8.0
https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.7.0/moment-with-langs.min.js
https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.0/moment-with-locales.min.js

I changed the logic to compare version, if after version 2.8.0, we will include 'moment-with-locales.min.js'
