### PR TITLE
Hide timestamps until rendering is complete.

### DIFF
--- a/flask_moment.py
+++ b/flask_moment.py
@@ -20,7 +20,7 @@ class _moment(object):
 moment.locale("en");
 function flask_moment_render(elem) {
     $(elem).text(eval('moment("' + $(elem).data('timestamp') + '").' + $(elem).data('format') + ';'));
-    $(elem).removeClass('flask-moment');
+    $(elem).removeClass('flask-moment').show();
 }
 function flask_moment_render_all() {
     $('.flask-moment').each(function() {
@@ -68,7 +68,8 @@ $(document).ready(function() {
     def _render(self, format, refresh=False):
         t = self._timestamp_as_iso_8601(self.timestamp)
         return Markup(('<span class="flask-moment" data-timestamp="%s" ' +
-                       'data-format="%s" data-refresh="%d">%s</span>') %
+                       'data-format="%s" data-refresh="%d" ' +
+                       'style="display: none">%s</span>') %
                       (t, format, int(refresh) * 60000, t))
 
     def format(self, fmt, refresh=False):


### PR DESCRIPTION
This is intended to mitigate the flicker issue in #1.

There's no way to completely remove flickering / reflow while the timestamps render, since Moment doesn't know how long the timestamp is going to be until it performs the formatting. There are two alternatives, both of which set a style on the templated timestamp and remove it after rendering is complete.

Setting `visibility: hidden` will result in a transparent element that is usually larger than the formatted timestamp (because ISO 8601 formatting is huge). Some reflow will occur due to the text content's length changing, so this is pretty much the same as before, minus the original timestamp being visible.

![visibility_hidden_before](https://cloud.githubusercontent.com/assets/3892845/9091022/d1d8b012-3b6b-11e5-90a2-8ee1298eeb05.png)
---
![visibility_hidden_after](https://cloud.githubusercontent.com/assets/3892845/9090372/e4052170-3b67-11e5-8e13-d3cd6217696a.png)

Setting `display: none` will remove the element until it's ready, and then significant reflow will occur.

![display_none_before](https://cloud.githubusercontent.com/assets/3892845/9090434/3d0c35ec-3b68-11e5-8b76-f840646d9e14.png)
---
![display_none_after](https://cloud.githubusercontent.com/assets/3892845/9090437/40481f32-3b68-11e5-88e7-107dac6d7d39.png)

Given that this occurs really quickly, I find the `display: none` approach to be less jarring, since it doesn't leave gaps in the text. `visibility: hidden` is an easy adjustment to make, too. So is leaving it as it is. Personal preference.