### PR TITLE
Adds live timestamps, updating in seconds and some minor tweaks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ Consult the [moment.js documentation](http://momentjs.com/) for details on these
 Auto-Refresh
 ------------
 
-All the display functions take an optional `refresh` argument that when set to a value larger than zero will re-render timestamps every &lt;value&gt; seconds. This can be useful for relative time formats such as the one returned by the `fromNow()` or `fromTime()` functions, or for showing a live clock. By default refreshing is disabled.
+All the display functions take an optional `refresh` argument that when set to a value larger than zero will re-render timestamps every <value> seconds. This can be useful for relative time formats such as the one returned by the `fromNow()` or `fromTime()` functions, or for showing a live clock. By default refreshing is disabled.
 
 Live timestamp
 ------------
 
-When using `refresh`, the used timestamp will be overwritten with the current one, allowing to do things like showing clocks:
+When using `live_timestamp`, the used timestamp will be overwritten with the current one, allowing to do things like showing clocks:
 
 Even though this updates every second, it will always show the time at which the page was rendered:
     {{ moment(now).format('HH:mm:ss', refresh=1) }}

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The `include_jquery()` and `include_moment()` methods take two optional argument
 
 Step 3: Render timestamps in your template. For example:
 
-    <p>The current date and time is: {{ moment().format('MMMM Do YYYY, h:mm:ss a') }}.</p>
+    <p>The current date and time is: {{ moment(live_timestamp=True).format('MMMM Do YYYY, h:mm:ss a') }}.</p>
     <p>Something happened {{ moment(then).fromTime(now) }}.</p>
     <p>{{ moment(then).calendar() }}.</p>
 
@@ -32,17 +32,20 @@ In the second and third examples template variables `then` and `now` are used. T
 
     now = datetime.utcnow()
 
-By default the timestamps will be converted from UTC to the local time in each client's machine before rendering. To disable the conversion to local time pass `local=True`. 
-    
+By default the timestamps will be converted from UTC to the local time in each client's machine before rendering. To disable the conversion to local time pass `local=True`.
+
 Note that even though the timestamps are provided in UTC the rendered dates and times will be in the local time of the client computer, so each users will always see their local time regardless of where they are located.
+
+In the first example, the parameter `live_timestamp` is used so the timestamp will be updated to use the current timestamp (instead of the time at which the page was rendered). This allows to, for example, show a clock.
 
 Function Reference
 ------------------
 
-The supported list of display functions is shown below:
+The supported list of display functions is as follows:
 
 - `moment(timestamp=None, local=False).format(format_string)`
 - `moment(timestamp=None, local=False).fromNow(no_suffix = False)`
+- `moment(timestamp=None, local=False).toNow(no_suffix = False)`
 - `moment(timestamp=None, local=False).fromTime(another_timesatmp, no_suffix = False)`
 - `moment(timestamp=None, local=False).calendar()`
 - `moment(timestamp=None, local=False).valueOf()`
@@ -53,7 +56,18 @@ Consult the [moment.js documentation](http://momentjs.com/) for details on these
 Auto-Refresh
 ------------
 
-All the display functions take an optional `refresh` argument that when set to `True` will re-render timestamps every minute. This can be useful for relative time formats such as the one returned by the `fromNow()` or `fromTime()` functions. By default refreshing is disabled.
+All the display functions take an optional `refresh` argument that when set to a value larger than zero will re-render timestamps every &lt;value&gt; seconds. This can be useful for relative time formats such as the one returned by the `fromNow()` or `fromTime()` functions, or for showing a live clock. By default refreshing is disabled.
+
+Live timestamp
+------------
+
+When using `refresh`, the used timestamp will be overwritten with the current one, allowing to do things like showing clocks:
+
+Even though this updates every second, it will always show the time at which the page was rendered:
+    {{ moment(now).format('HH:mm:ss', refresh=1) }}
+
+This will show the current time and updates it every second:
+    {{ moment(live_timestamp=True).format('HH:mm:ss', refresh=1) }}
 
 Internationalization
 --------------------
@@ -61,7 +75,7 @@ Internationalization
 By default dates and times are rendered in English. To change to a different language add the following line in the `<head>` section after the `include_moment()` line:
 
     {{ moment.lang("es") }}
-    
+
 The above example sets the language to Spanish. Moment.js supports a large number of languages, consult the documentation for the list of languages and their two letter codes.
 
 Ajax Support

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ All the display functions take an optional `refresh` argument that when set to a
 Live timestamp
 ------------
 
-When using `live_timestamp`, the used timestamp will be overwritten with the current one, allowing to do things like showing clocks:
+With `live` the current timestamp is used, allowing to do things like creating clocks:
 
 Even though this updates every second, it will always show the time at which the page was rendered:
-    {{ moment(now).format('HH:mm:ss', refresh=1) }}
+    {{ moment(now).format('HH:mm:ss', refresh=True, refresh_rate=1) }}
 
 This will show the current time and updates it every second:
-    {{ moment(live_timestamp=True).format('HH:mm:ss', refresh=1) }}
+    {{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=1) }}
 
 Internationalization
 --------------------

--- a/example/app.py
+++ b/example/app.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from datetime import datetime
 from flask import Flask, render_template, jsonify
 from flask.ext.moment import Moment
@@ -9,12 +11,12 @@ moment = Moment(app)
 def index():
     now = datetime.utcnow()
     midnight = datetime(now.year, now.month, now.day, 0, 0, 0)
-    epoch = datetime(1970, 1, 1, 0, 0, 0) 
+    epoch = datetime(1970, 1, 1, 0, 0, 0)
     return render_template('index.html', now=now, midnight=midnight, epoch=epoch)
 
 @app.route('/ajax')
 def ajax():
     return jsonify({ 'timestamp': moment.create(datetime.utcnow()).format('LLLL') });
- 
+
 if __name__ == '__main__':
     app.run(debug = True)

--- a/example/app.py
+++ b/example/app.py
@@ -12,7 +12,8 @@ def index():
     now = datetime.utcnow()
     midnight = datetime(now.year, now.month, now.day, 0, 0, 0)
     epoch = datetime(1970, 1, 1, 0, 0, 0)
-    return render_template('index.html', now=now, midnight=midnight, epoch=epoch)
+    live = 'live'
+    return render_template('index.html', now=now, midnight=midnight, epoch=epoch, live=live)
 
 @app.route('/ajax')
 def ajax():

--- a/example/app.py
+++ b/example/app.py
@@ -16,7 +16,7 @@ def index():
 
 @app.route('/ajax')
 def ajax():
-    return jsonify({ 'timestamp': moment.create(datetime.utcnow()).format('LLLL') });
+    return jsonify({ 'timestamp': moment.create(datetime.utcnow()).format('dddd, MMMM Do YYYY LTS ') });
 
 if __name__ == '__main__':
     app.run(debug = True)

--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -3,44 +3,130 @@
         <title>Flask-Moment example app</title>
         {{ moment.include_jquery() }}
         {{ moment.include_moment() }}
-        <script>
-        function load_ajax_timestamp() {
+        <style type="text/css">
+            body{
+                font-family: arial;
+            }
+            .wrapper{
+                width: 800px;
+                margin: auto;
+            }
+            code, .output{
+                display: block;
+                padding: 10px;
+                border: 1px solid #cccccc;
+                background-color: #eeeeee;
+                font-family: courier;
+            }
+            .output{
+                background-color: white;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="wrapper">
+            <h1>Flask-Moment</h1>
+            <h3>Getting started</h3>
+            <p>Include Flask-Moment and its jQuery bindings to the <b>&lt;head&gt;</b> of your page. If you want to use a local version of jquery, use the <b>local_js</b> parameter. Omit this parameter to use the jquery CDN</p>
+            <code>
+                <span>{</span>{ moment.include_jquery() }}<br />
+                <span>{</span>{ moment.include_moment() }}
+            </code>
+            <p>or</p>
+            <code>
+                <span>{</span>{ moment.include_jquery( local_js="/path/to/local/jquery.js" ) }}<br />
+                <span>{</span>{ moment.include_moment() }}
+            </code>
+
+            <h3>Now</h3>
+            <p> If you want to use the time at which the page was rendered, use <b>now</b>.</p>
+            <code>This page was rendered on <b><span>{</span>{ moment(now).format('LLL') }}</b>.</code>
+            <span class="output">This page was rendered on <b>{{ moment().format('LLL') }}</b>.</span>
+
+            <h3>Refresh</h3>
+            <p>You can use the optional <b>refresh</b> argument to automatically update and redraw the time difference. By default, a refresh is done once every 60 seconds.</p>
+            <code>This page was rendered <b><span>{</span>{ moment(now).fromNow(refresh=True) }}</b>.</code>
+            <span class="output">This page was rendered <b>{{ moment(now).fromNow(refresh=True) }}</b>.</span>
+
+            <h3>Live</h3>
+            <p>When you need the current time, you can use <b>live</b> instead:</p>
+            <code>
+                Current time, refreshing every minute: <b><span>{</span>{ moment(live).format('HH:mm:ss', refresh=True) }}</b><br />
+            </code>
+            <span class="output">
+                Current time, refreshing every minute: <b>{{ moment(live).format('HH:mm:ss', refresh=True) }}</b><br />
+            </span>
+
+            <h3>Refresh_rate</h3>
+            <p>By default <b>refresh</b> triggers an update every minute. You can set the update speed (in seconds) using <b>refresh_rate</b>:</p>
+            <code>
+                Current time, refreshing every second: <b><span>{</span>{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=1) }}</b>
+            </code>
+            <span class="output">
+                Current time, refreshing every second: <b>{{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=1) }}</b>
+            </span>
+
+
+            <h3>Ajax</h3>
+            <p>Flask-Moment can also be used for ajax calls:</p>
+            <div id="ajax"></div>
+            <a href="#" id="ajaxLink">Load Ajax timestamp</a>
+
+
+            <h3>Examples</h3>
+            <code>The current date and time is: <b><span>{</span>{ moment(live).format('MMMM Do YYYY, h:mm:ss a', refresh=True, refresh_rate=1) }}</b></code>
+            <span class="output">The current date and time is: <b>{{ moment(live).format('MMMM Do YYYY, h:mm:ss a', refresh=True, refresh_rate=1) }}</b></span>
+
+            <br />
+
+            <code>
+                Clock: update every second: <b><span>{</span>{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=1) }}</b><br />
+                Clock, update every minute: <b><span>{</span>{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=60) }}</b><br />
+                Clock, update every hour: <b><span>{</span>{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=360) }}</b>
+            </code>
+
+            <span class="output">
+                Clock: update every second: <b>{{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=1) }}</b><br />
+                Clock, update every minute: <b>{{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=60) }}</b><br />
+                Clock, update every hour: <b>{{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=360) }}</b>
+            </span>
+
+            <br />
+
+            <code>
+                <b><span>{</span>{ moment(midnight).fromTime(now) }}</b> it was midnight in the UTC timezone.<br />
+                That was <b><span>{</span>{ moment(midnight).calendar() }}</b> in your local time.
+            </code>
+            <span class="output">
+                <b>{{ moment(midnight).fromTime(now) }}</b> it was midnight in the UTC timezone.<br />
+                That was <b>{{ moment(midnight).calendar() }}</b> in your local time.
+            </span>
+
+            <br />
+
+            <code>
+                Unix epoch is <b><span>{</span>{ moment(epoch, local=True).format('LLLL') }}<b> in the UTC timezone.<br />
+                That was <b><span>{</span>{ moment(epoch).format('LLLL') }}<b> in your local time.
+            </code>
+            <span class="output">
+                Unix epoch is <b>{{ moment(epoch, local=True).format('LLLL') }}<b> in the UTC timezone.<br />
+                That was <b>{{ moment(epoch).format('LLLL') }}<b> in your local time.
+            </span>
+        </b>
+
+        <script type="text/javascript">
+        $('#ajaxLink').click(function(event) {
+            event.preventDefault();
+            console.log("go");
             $.ajax({
                 url: '{{ url_for('ajax') }}',
                 dataType: 'json'
             }).done(function(response) {
-                $('#ajax').append('<p>' + response.timestamp + '</p>');
+                $('#ajax').append('<span class="output">' + response.timestamp + '</span>');
                 flask_moment_render_all();
             });
-        }
+        });
         </script>
-    </head>
-    <body>
-    Even though this updates every second, it will always show the time at which the page was rendered:
-    {{ moment(now).format('HH:mm:ss', refresh=1) }}
 
-This will show the current time and updates it every second:
-    {{ moment(live_timestamp=True).format('HH:mm:ss', refresh=1) }}
-
-        <p>
-            This page was rendered on {{ moment(now).format('LLL') }},
-            which was {{ moment(live_timestamp=True).fromNow(refresh=60) }}.
-        </p>
-        <p>The current date and time is: {{ moment(live_timestamp=True).format('MMMM Do YYYY, h:mm:ss a', refresh=1) }}.</p>
-        <p>
-            This clock is updated every second: {{ moment(live_timestamp=True).format('HH:mm:ss', refresh=1) }}.<br />
-            This clock is updated every ten seconds: {{ moment(live_timestamp=True).format('HH:mm:ss', refresh=10) }}.<br />
-            This clock does not update: {{ moment(live_timestamp=True).format('HH:mm:ss', refresh=False) }}.
-        </p>
-        <p>
-            {{ moment(midnight).fromTime(now) }} it was midnight in the UTC timezone.<br />
-            That was {{ moment(midnight).calendar() }} in your local time.
-        </p>
-        <p>
-            Unix epoch is {{ moment(epoch, local=True).format('LLLL') }} in the UTC timezone.<br />
-            That was {{ moment(epoch).format('LLLL') }} in your local time.
-        </p>
-        <div id="ajax"></div>
-        <a href="#" onclick="load_ajax_timestamp()">Load Ajax timestamp</a>
     </body>
 </html>

--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -16,18 +16,29 @@
         </script>
     </head>
     <body>
-        <p>The current date and time is: {{ moment().format('MMMM Do YYYY, h:mm:ss a') }}.</p>
+    Even though this updates every second, it will always show the time at which the page was rendered:
+    {{ moment(now).format('HH:mm:ss', refresh=1) }}
+
+This will show the current time and updates it every second:
+    {{ moment(live_timestamp=True).format('HH:mm:ss', refresh=1) }}
+
         <p>
-            {{ moment(midnight).fromTime(now) }} it was midnight in the UTC timezone. 
+            This page was rendered on {{ moment(now).format('LLL') }},
+            which was {{ moment(live_timestamp=True).fromNow(refresh=60) }}.
+        </p>
+        <p>The current date and time is: {{ moment(live_timestamp=True).format('MMMM Do YYYY, h:mm:ss a', refresh=1) }}.</p>
+        <p>
+            This clock is updated every second: {{ moment(live_timestamp=True).format('HH:mm:ss', refresh=1) }}.<br />
+            This clock is updated every ten seconds: {{ moment(live_timestamp=True).format('HH:mm:ss', refresh=10) }}.<br />
+            This clock does not update: {{ moment(live_timestamp=True).format('HH:mm:ss', refresh=False) }}.
+        </p>
+        <p>
+            {{ moment(midnight).fromTime(now) }} it was midnight in the UTC timezone.<br />
             That was {{ moment(midnight).calendar() }} in your local time.
         </p>
         <p>
-            Unix epoch is {{ moment(epoch, local=True).format('LLLL') }} in the UTC timezone.
+            Unix epoch is {{ moment(epoch, local=True).format('LLLL') }} in the UTC timezone.<br />
             That was {{ moment(epoch).format('LLLL') }} in your local time.
-        </p>
-        <p>
-            This page was rendered on {{ moment(now).format('LLL') }},
-            which was {{ moment(now).fromNow(refresh = True) }}.
         </p>
         <div id="ajax"></div>
         <a href="#" onclick="load_ajax_timestamp()">Load Ajax timestamp</a>

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from jinja2 import Markup
 from flask import current_app
 
-
 class _moment(object):
     @staticmethod
     def include_moment(version='2.10.3', local_js=None):
@@ -55,12 +54,16 @@ $(document).ready(function() {
     def lang(language):
         return _moment.locale(language)
 
-    def __init__(self, timestamp=None, local=False, live_timestamp=False):
-        if timestamp == None:
+    def __init__(self, timestamp=None, local=False):
+
+        self.live_timestamp = False
+        if timestamp == None or timestamp == 'live':
+            if timestamp == 'live':
+                self.live_timestamp = True
             timestamp = datetime.utcnow()
+
         self.timestamp = timestamp
         self.local = local
-        self.live_timestamp = live_timestamp
 
     def _timestamp_as_iso_8601(self, timestamp):
         tz = ''
@@ -68,35 +71,35 @@ $(document).ready(function() {
             tz = 'Z'
         return timestamp.strftime('%Y-%m-%dT%H:%M:%S' + tz)
 
-    def _render(self, format, refresh=False):
+    def _render(self, format, refresh=False, refresh_rate=60):
         t = self._timestamp_as_iso_8601(self.timestamp)
         return Markup(('<span class="flask-moment" data-timestamp="{0}" ' +
                    'data-format="{1}" data-refresh="{2}" data-live-timestamp="{3}" ' +
                    'style="display: none">{4}</span>').format(
-                    t, format, int(refresh) * 1000, self.live_timestamp, t))
+                    t, format, int(refresh) * (refresh_rate*1000), self.live_timestamp, t))
 
-    def format(self, fmt, refresh=False):
-        return self._render("format('%s')" % fmt, refresh)
+    def format(self, fmt, refresh=False, refresh_rate=60):
+        return self._render("format('%s')" % fmt, refresh, refresh_rate)
 
-    def fromNow(self, no_suffix=False, refresh=False):
-        return self._render("fromNow(%s)" % int(no_suffix), refresh)
+    def fromNow(self, no_suffix=False, refresh=False, refresh_rate=60):
+        return self._render("fromNow(%s)" % int(no_suffix), refresh, refresh_rate)
 
-    def toNow(self, no_suffix=False, refresh=False):
-        return self._render("toNow(%s)" % int(no_suffix), refresh)
+    def toNow(self, no_suffix=False, refresh=False, refresh_rate=60):
+        return self._render("toNow(%s)" % int(no_suffix), refresh, refresh_rate)
 
-    def fromTime(self, timestamp, no_suffix=False, refresh=False):
+    def fromTime(self, timestamp, no_suffix=False, refresh=False, refresh_rate=60):
         return self._render("from(moment('%s'),%s)" %
                             (self._timestamp_as_iso_8601(timestamp),
-                             int(no_suffix)), refresh)
+                             int(no_suffix)), refresh, refresh_rate)
 
-    def calendar(self, refresh=False):
-        return self._render("calendar()", refresh)
+    def calendar(self, refresh=False, refresh_rate=60):
+        return self._render("calendar()", refresh, refresh_rate)
 
-    def valueOf(self, refresh=False):
-        return self._render("valueOf()", refresh)
+    def valueOf(self, refresh=False, refresh_rate=60):
+        return self._render("valueOf()", refresh, refresh_rate)
 
-    def unix(self, refresh=False):
-        return self._render("unix()", refresh)
+    def unix(self, refresh=False, refresh_rate=60):
+        return self._render("unix()", refresh, refresh_rate)
 
 
 class Moment(object):

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -25,7 +25,8 @@ function flask_moment_render(elem) {
 function flask_moment_render_all() {
     $('.flask-moment').each(function() {
         flask_moment_render(this);
-        if ($(this).data('refresh')) {
+        if ($(this).data('refresh') && !$(this).data('has_timer)) {
+            $(this).data('has_timer', true);
             (function(elem, interval) { setInterval(function() { flask_moment_render(elem) }, interval); })(this, $(this).data('refresh'));
         }
     })

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -81,6 +81,9 @@ $(document).ready(function() {
     def fromNow(self, no_suffix=False, refresh=False):
         return self._render("fromNow(%s)" % int(no_suffix), refresh)
 
+    def toNow(self, no_suffix=False, refresh=False):
+        return self._render("toNow(%s)" % int(no_suffix), refresh)
+
     def fromTime(self, timestamp, no_suffix=False, refresh=False):
         return self._render("from(moment('%s'),%s)" %
                             (self._timestamp_as_iso_8601(timestamp),

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -19,7 +19,7 @@ class _moment(object):
         return Markup('''%s<script>
 moment.locale("en");
 function flask_moment_render(elem) {
-    if($(elem).data('is-clock') === "True"){ $(elem).text(eval('moment().' + $(elem).data('format') + ';')); }
+    if($(elem).data('live-timestamp') === "True"){ $(elem).text(eval('moment().' + $(elem).data('format') + ';')); }
     else { $(elem).text(eval('moment("' + $(elem).data('timestamp') + '").' + $(elem).data('format') + ';')); }
     $(elem).removeClass('flask-moment').show();
 }
@@ -55,12 +55,12 @@ $(document).ready(function() {
     def lang(language):
         return _moment.locale(language)
 
-    def __init__(self, timestamp=None, local=False, use_now=False):
+    def __init__(self, timestamp=None, local=False, live_timestamp=False):
         if timestamp == None:
             timestamp = datetime.utcnow()
         self.timestamp = timestamp
         self.local = local
-        self.use_now = use_now
+        self.live_timestamp = live_timestamp
 
     def _timestamp_as_iso_8601(self, timestamp):
         tz = ''
@@ -71,9 +71,9 @@ $(document).ready(function() {
     def _render(self, format, refresh=False):
         t = self._timestamp_as_iso_8601(self.timestamp)
         return Markup(('<span class="flask-moment" data-timestamp="{0}" ' +
-                   'data-format="{1}" data-refresh="{2}" data-is-clock="{3}" ' +
+                   'data-format="{1}" data-refresh="{2}" data-live-timestamp="{3}" ' +
                    'style="display: none">{4}</span>').format(
-                    t, format, int(refresh) * 1000, self.use_now, t))
+                    t, format, int(refresh) * 1000, self.live_timestamp, t))
 
     def format(self, fmt, refresh=False):
         return self._render("format('%s')" % fmt, refresh)

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -19,13 +19,14 @@ class _moment(object):
         return Markup('''%s<script>
 moment.locale("en");
 function flask_moment_render(elem) {
-    $(elem).text(eval('moment("' + $(elem).data('timestamp') + '").' + $(elem).data('format') + ';'));
+    if($(elem).data('is-clock') === "True"){ $(elem).text(eval('moment().' + $(elem).data('format') + ';')); }
+    else { $(elem).text(eval('moment("' + $(elem).data('timestamp') + '").' + $(elem).data('format') + ';')); }
     $(elem).removeClass('flask-moment').show();
 }
 function flask_moment_render_all() {
     $('.flask-moment').each(function() {
         flask_moment_render(this);
-        if ($(this).data('refresh') && !$(this).data('has_timer)) {
+        if ($(this).data('refresh') && !$(this).data('has_timer')) {
             $(this).data('has_timer', true);
             (function(elem, interval) { setInterval(function() { flask_moment_render(elem) }, interval); })(this, $(this).data('refresh'));
         }
@@ -54,11 +55,12 @@ $(document).ready(function() {
     def lang(language):
         return _moment.locale(language)
 
-    def __init__(self, timestamp=None, local=False):
-        if timestamp is None:
+    def __init__(self, timestamp=None, local=False, use_now=False):
+        if timestamp == None:
             timestamp = datetime.utcnow()
         self.timestamp = timestamp
         self.local = local
+        self.use_now = use_now
 
     def _timestamp_as_iso_8601(self, timestamp):
         tz = ''
@@ -68,10 +70,10 @@ $(document).ready(function() {
 
     def _render(self, format, refresh=False):
         t = self._timestamp_as_iso_8601(self.timestamp)
-        return Markup(('<span class="flask-moment" data-timestamp="%s" ' +
-                       'data-format="%s" data-refresh="%d" ' +
-                       'style="display: none">%s</span>') %
-                      (t, format, int(refresh) * 60000, t))
+        return Markup(('<span class="flask-moment" data-timestamp="{0}" ' +
+                   'data-format="{1}" data-refresh="{2}" data-is-clock="{3}" ' +
+                   'style="display: none">{4}</span>').format(
+                    t, format, int(refresh) * 1000, self.use_now, t))
 
     def format(self, fmt, refresh=False):
         return self._render("format('%s')" % fmt, refresh)


### PR DESCRIPTION
The updates in this pull request are backwards compatible, EXCEPT for the refresh value: 
To me, using the `refresh` option with seconds seems to make more sense than minutes. Using `refresh=60` to refresh every minute seems more clear than having to use `refresh=0.0166` to refresh every second.

This pull request adds the following:

* When a timer is attached to an element, the element gets a `has-timer` data object. This way, when attaching timers, the script can first check if an element already has a timer or not. Without this check an element can receive multiple timers which can easily happen when parts of the page get dynamically loaded and you need to attach timers to newly created elements.
* You can now call `moment(live_timestamp=True)` to have the timestamp always be current. This means that with every refresh, the element's timestamp data object will be overwritten with the current datastamp. This allows you to easily show things like clocks.

Smaller changes:
* Adds Moment.js' toNow function to the available methods.
* The Ajax load timestamp link in the example file now shows a timestamp with seconds, to show its function more clearly.
* Adds shebang + permissions to app.py so you can run it with `./app.py` instead of `python app.py`.
