### PR TITLE
Adds live option + custom refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The `include_jquery()` and `include_moment()` methods take two optional argument
 
 Step 3: Render timestamps in your template. For example:
 
-    <p>The current date and time is: {{ moment(live_timestamp=True).format('MMMM Do YYYY, h:mm:ss a') }}.</p>
+    <p>The current date and time is: {{ moment(now).format('MMMM Do YYYY, h:mm:ss a') }}.</p>
     <p>Something happened {{ moment(then).fromTime(now) }}.</p>
     <p>{{ moment(then).calendar() }}.</p>
 
@@ -47,8 +47,6 @@ In the second and third examples template variables `then` and `now` are used. T
 By default the timestamps will be converted from UTC to the local time in each client's machine before rendering. To disable the conversion to local time pass `local=True`.
 
 Note that even though the timestamps are provided in UTC the rendered dates and times will be in the local time of the client computer, so each users will always see their local time regardless of where they are located.
-
-In the first example, the parameter `live_timestamp` is used so the timestamp will be updated to use the current timestamp (instead of the time at which the page was rendered). This allows to, for example, show a clock.
 
 Function Reference
 ------------------
@@ -68,7 +66,7 @@ Consult the [moment.js documentation](http://momentjs.com/) for details on these
 Auto-Refresh
 ------------
 
-All the display functions take an optional `refresh` argument that when set to a value larger than zero will re-render timestamps every <value> seconds. This can be useful for relative time formats such as the one returned by the `fromNow()` or `fromTime()` functions, or for showing a live clock. By default refreshing is disabled.
+All the display functions take an optional `refresh` argument that when set to `True` will re-render the timestamp every 60 seconds. You can set the interval using `refresh_rate=<seconds>`. This can be useful for relative time formats such as the one returned by the `fromNow()` or `fromTime()` functions, or for showing a live clock. By default refreshing is disabled.
 
 Live timestamp
 ------------

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The `include_jquery()` and `include_moment()` methods take two optional argument
 
 Step 3: Render timestamps in your template. For example:
 
-    <p>The current date and time is: {{ moment().format('MMMM Do YYYY, h:mm:ss a') }}.</p>
+    <p>The current date and time is: {{ moment(live_timestamp=True).format('MMMM Do YYYY, h:mm:ss a') }}.</p>
     <p>Something happened {{ moment(then).fromTime(now) }}.</p>
     <p>{{ moment(then).calendar() }}.</p>
 
@@ -44,17 +44,20 @@ In the second and third examples template variables `then` and `now` are used. T
 
     now = datetime.utcnow()
 
-By default the timestamps will be converted from UTC to the local time in each client's machine before rendering. To disable the conversion to local time pass `local=True`. 
-    
+By default the timestamps will be converted from UTC to the local time in each client's machine before rendering. To disable the conversion to local time pass `local=True`.
+
 Note that even though the timestamps are provided in UTC the rendered dates and times will be in the local time of the client computer, so each users will always see their local time regardless of where they are located.
+
+In the first example, the parameter `live_timestamp` is used so the timestamp will be updated to use the current timestamp (instead of the time at which the page was rendered). This allows to, for example, show a clock.
 
 Function Reference
 ------------------
 
-The supported list of display functions is shown below:
+The supported list of display functions is as follows:
 
 - `moment(timestamp=None, local=False).format(format_string)`
 - `moment(timestamp=None, local=False).fromNow(no_suffix = False)`
+- `moment(timestamp=None, local=False).toNow(no_suffix = False)`
 - `moment(timestamp=None, local=False).fromTime(another_timesatmp, no_suffix = False)`
 - `moment(timestamp=None, local=False).calendar()`
 - `moment(timestamp=None, local=False).valueOf()`
@@ -65,7 +68,18 @@ Consult the [moment.js documentation](http://momentjs.com/) for details on these
 Auto-Refresh
 ------------
 
-All the display functions take an optional `refresh` argument that when set to `True` will re-render timestamps every minute. This can be useful for relative time formats such as the one returned by the `fromNow()` or `fromTime()` functions. By default refreshing is disabled.
+All the display functions take an optional `refresh` argument that when set to a value larger than zero will re-render timestamps every <value> seconds. This can be useful for relative time formats such as the one returned by the `fromNow()` or `fromTime()` functions, or for showing a live clock. By default refreshing is disabled.
+
+Live timestamp
+------------
+
+With `live` the current timestamp is used, allowing to do things like creating clocks:
+
+Even though this updates every second, it will always show the time at which the page was rendered:
+    {{ moment(now).format('HH:mm:ss', refresh=True, refresh_rate=1) }}
+
+This will show the current time and updates it every second:
+    {{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=1) }}
 
 Internationalization
 --------------------
@@ -73,7 +87,7 @@ Internationalization
 By default dates and times are rendered in English. To change to a different language add the following line in the `<head>` section after the `include_moment()` line:
 
     {{ moment.lang("es") }}
-    
+
 The above example sets the language to Spanish. Moment.js supports a large number of languages, consult the documentation for the list of languages and their two letter codes.
 
 Ajax Support

--- a/example/app.py
+++ b/example/app.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from datetime import datetime
 from flask import Flask, render_template, jsonify
 from flask_moment import Moment
@@ -9,12 +11,13 @@ moment = Moment(app)
 def index():
     now = datetime.utcnow()
     midnight = datetime(now.year, now.month, now.day, 0, 0, 0)
-    epoch = datetime(1970, 1, 1, 0, 0, 0) 
-    return render_template('index.html', now=now, midnight=midnight, epoch=epoch)
+    epoch = datetime(1970, 1, 1, 0, 0, 0)
+    live = 'live'
+    return render_template('index.html', now=now, midnight=midnight, epoch=epoch, live=live)
 
 @app.route('/ajax')
 def ajax():
-    return jsonify({ 'timestamp': moment.create(datetime.utcnow()).format('LLLL') });
- 
+    return jsonify({ 'timestamp': moment.create(datetime.utcnow()).format('dddd, MMMM Do YYYY LTS ') });
+
 if __name__ == '__main__':
     app.run(debug = True)

--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -3,33 +3,130 @@
         <title>Flask-Moment example app</title>
         {{ moment.include_jquery() }}
         {{ moment.include_moment() }}
-        <script>
-        function load_ajax_timestamp() {
+        <style type="text/css">
+            body{
+                font-family: arial;
+            }
+            .wrapper{
+                width: 800px;
+                margin: auto;
+            }
+            code, .output{
+                display: block;
+                padding: 10px;
+                border: 1px solid #cccccc;
+                background-color: #eeeeee;
+                font-family: courier;
+            }
+            .output{
+                background-color: white;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="wrapper">
+            <h1>Flask-Moment</h1>
+            <h3>Getting started</h3>
+            <p>Include Flask-Moment and its jQuery bindings to the <b>&lt;head&gt;</b> of your page. If you want to use a local version of jquery, use the <b>local_js</b> parameter. Omit this parameter to use the jquery CDN</p>
+            <code>
+                <span>{</span>{ moment.include_jquery() }}<br />
+                <span>{</span>{ moment.include_moment() }}
+            </code>
+            <p>or</p>
+            <code>
+                <span>{</span>{ moment.include_jquery( local_js="/path/to/local/jquery.js" ) }}<br />
+                <span>{</span>{ moment.include_moment() }}
+            </code>
+
+            <h3>Now</h3>
+            <p> If you want to use the time at which the page was rendered, use <b>now</b>.</p>
+            <code>This page was rendered on <b><span>{</span>{ moment(now).format('LLL') }}</b>.</code>
+            <span class="output">This page was rendered on <b>{{ moment().format('LLL') }}</b>.</span>
+
+            <h3>Refresh</h3>
+            <p>You can use the optional <b>refresh</b> argument to automatically update and redraw the time difference. By default, a refresh is done once every 60 seconds.</p>
+            <code>This page was rendered <b><span>{</span>{ moment(now).fromNow(refresh=True) }}</b>.</code>
+            <span class="output">This page was rendered <b>{{ moment(now).fromNow(refresh=True) }}</b>.</span>
+
+            <h3>Live</h3>
+            <p>When you need the current time, you can use <b>live</b> instead:</p>
+            <code>
+                Current time, refreshing every minute: <b><span>{</span>{ moment(live).format('HH:mm:ss', refresh=True) }}</b><br />
+            </code>
+            <span class="output">
+                Current time, refreshing every minute: <b>{{ moment(live).format('HH:mm:ss', refresh=True) }}</b><br />
+            </span>
+
+            <h3>Refresh_rate</h3>
+            <p>By default <b>refresh</b> triggers an update every minute. You can set the update speed (in seconds) using <b>refresh_rate</b>:</p>
+            <code>
+                Current time, refreshing every second: <b><span>{</span>{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=1) }}</b>
+            </code>
+            <span class="output">
+                Current time, refreshing every second: <b>{{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=1) }}</b>
+            </span>
+
+
+            <h3>Ajax</h3>
+            <p>Flask-Moment can also be used for ajax calls:</p>
+            <div id="ajax"></div>
+            <a href="#" id="ajaxLink">Load Ajax timestamp</a>
+
+
+            <h3>Examples</h3>
+            <code>The current date and time is: <b><span>{</span>{ moment(live).format('MMMM Do YYYY, h:mm:ss a', refresh=True, refresh_rate=1) }}</b></code>
+            <span class="output">The current date and time is: <b>{{ moment(live).format('MMMM Do YYYY, h:mm:ss a', refresh=True, refresh_rate=1) }}</b></span>
+
+            <br />
+
+            <code>
+                Clock: update every second: <b><span>{</span>{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=1) }}</b><br />
+                Clock, update every minute: <b><span>{</span>{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=60) }}</b><br />
+                Clock, update every hour: <b><span>{</span>{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=360) }}</b>
+            </code>
+
+            <span class="output">
+                Clock: update every second: <b>{{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=1) }}</b><br />
+                Clock, update every minute: <b>{{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=60) }}</b><br />
+                Clock, update every hour: <b>{{ moment(live).format('HH:mm:ss', refresh=True, refresh_rate=360) }}</b>
+            </span>
+
+            <br />
+
+            <code>
+                <b><span>{</span>{ moment(midnight).fromTime(now) }}</b> it was midnight in the UTC timezone.<br />
+                That was <b><span>{</span>{ moment(midnight).calendar() }}</b> in your local time.
+            </code>
+            <span class="output">
+                <b>{{ moment(midnight).fromTime(now) }}</b> it was midnight in the UTC timezone.<br />
+                That was <b>{{ moment(midnight).calendar() }}</b> in your local time.
+            </span>
+
+            <br />
+
+            <code>
+                Unix epoch is <b><span>{</span>{ moment(epoch, local=True).format('LLLL') }}<b> in the UTC timezone.<br />
+                That was <b><span>{</span>{ moment(epoch).format('LLLL') }}<b> in your local time.
+            </code>
+            <span class="output">
+                Unix epoch is <b>{{ moment(epoch, local=True).format('LLLL') }}<b> in the UTC timezone.<br />
+                That was <b>{{ moment(epoch).format('LLLL') }}<b> in your local time.
+            </span>
+        </b>
+
+        <script type="text/javascript">
+        $('#ajaxLink').click(function(event) {
+            event.preventDefault();
+            console.log("go");
             $.ajax({
                 url: '{{ url_for('ajax') }}',
                 dataType: 'json'
             }).done(function(response) {
-                $('#ajax').append('<p>' + response.timestamp + '</p>');
+                $('#ajax').append('<span class="output">' + response.timestamp + '</span>');
                 flask_moment_render_all();
             });
-        }
+        });
         </script>
-    </head>
-    <body>
-        <p>The current date and time is: {{ moment().format('MMMM Do YYYY, h:mm:ss a') }}.</p>
-        <p>
-            {{ moment(midnight).fromTime(now) }} it was midnight in the UTC timezone. 
-            That was {{ moment(midnight).calendar() }} in your local time.
-        </p>
-        <p>
-            Unix epoch is {{ moment(epoch, local=True).format('LLLL') }} in the UTC timezone.
-            That was {{ moment(epoch).format('LLLL') }} in your local time.
-        </p>
-        <p>
-            This page was rendered on {{ moment(now).format('LLL') }},
-            which was {{ moment(now).fromNow(refresh = True) }}.
-        </p>
-        <div id="ajax"></div>
-        <a href="#" onclick="load_ajax_timestamp()">Load Ajax timestamp</a>
+
     </body>
 </html>


### PR DESCRIPTION
- Changes in this commit allow for the use of a 'live' timestamp. See the example file for a live demo.
- Prevents starting multiple timers for a single object
- Refresh now allows for other values (like every second).
- Adds a toNow function
- All changes are backwards compatible.
