### PR TITLE
Support not load javascript resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This extension also supports the [Flask application factory pattern](http://flas
 
 Note that jQuery is required. If you are already including it on your own then you can remove the `include_jquery()` line. Secure HTTP is used if the request under which these are executed is secure.
 
-The `include_jquery()` and `include_moment()` methods take two optional arguments. If you pass `version`, then the requested version will be loaded from the CDN. If you pass `local_js`, then the given local path will be used to load the library.
+The `include_jquery()` and `include_moment()` methods take two optional arguments. If you pass `version`, then the requested version will be loaded from the CDN. If you pass `local_js`, then the given local path will be used to load the library. If you want to load the javascript by yourself, you can just set `local_js` to `''`. 
 
 Step 3: Render timestamps in your template. For example:
 

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -9,7 +9,10 @@ class _moment(object):
     def include_moment(version='2.18.1', local_js=None):
         js = ''
         if local_js is not None:
-            js = '<script src="%s"></script>\n' % local_js
+            if local_js == '':
+                js = ''
+            else:
+                js = '<script src="%s"></script>\n' % local_js
         elif version is not None:
             js_filename = 'moment-with-locales.min.js' \
                 if StrictVersion(version) >= StrictVersion('2.8.0') \

--- a/tests/test_flask_moment.py
+++ b/tests/test_flask_moment.py
@@ -77,6 +77,12 @@ class TestFlaskMomentIncludes(object):
         assert "<script src=\"/path/to/local/moment.js\"></script>" in str(
             include_moment)
 
+    def test_not_include_moment(self):
+        include_moment = _moment.include_moment(local_js="")
+
+        assert isinstance(include_moment, Markup)
+        assert "<script" not in str(include_moment)
+
     def test_include_moment_renders_properly(self, app, moment):
         ts = str(render_template_string("{{ moment.include_moment() }}"))
 

--- a/tests/test_flask_moment.py
+++ b/tests/test_flask_moment.py
@@ -81,7 +81,7 @@ class TestFlaskMomentIncludes(object):
         include_moment = _moment.include_moment(local_js="")
 
         assert isinstance(include_moment, Markup)
-        assert "<script" not in str(include_moment)
+        assert "<script src=" not in str(include_moment)
 
     def test_include_moment_renders_properly(self, app, moment):
         ts = str(render_template_string("{{ moment.include_moment() }}"))


### PR DESCRIPTION
This PR add support to not add `<script>` tag in `include_moment()`. 

When using Flask-Assets or something similar, you want to merge all the javascript file to optimize page loading, then the `<script>` in `include_moment()` will be redundant.

- [x] Add test
- [x] Update README