### PR TITLE
Add Subresource Integrity to Flask_Moment

### DIFF
--- a/flask_moment.py
+++ b/flask_moment.py
@@ -24,7 +24,7 @@ class _moment(object):
                     path = '//cdnjs.cloudflare.com/ajax/libs/moment.js/%s/%s' % (version, js_filename)
                     h_64 = _moment._sri_hash(_moment._get_data(
                         'https:%s' % path))
-                    js = '<script src="https://%s" integrity="%s" crossorigin="anonymous"></script>\n' % (path, h_64)
+                    js = '<script src="%s" integrity="%s" crossorigin="anonymous"></script>\n' % (path, h_64)
                 else:
                     js = '<script src="//cdnjs.cloudflare.com/ajax/libs/' \
                          'moment.js/%s/%s"></script>\n' % (version, js_filename)

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -80,6 +80,7 @@ $(document).ready(function() {
     @staticmethod
     @lru_cache()
     def _sri_hash(data):
+        print("Hashing..")
         h = hashlib.sha384(data).digest()
         h_64 = base64.b64encode(h).decode()
         return 'sha384-{}'.format(h_64)

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -2,7 +2,6 @@ from distutils.version import StrictVersion
 from datetime import datetime
 from jinja2 import Markup
 from flask import current_app
-from functools import lru_cache
 import hashlib
 import base64
 import urllib.request
@@ -21,13 +20,16 @@ class _moment(object):
                     if StrictVersion(version) >= StrictVersion('2.8.0') \
                     else 'moment-with-langs.min.js'
                 if sri:
-                    path = 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/%s/%s' % (version, js_filename)
+                    path = ('https://cdnjs.cloudflare.com/ajax/' +
+                            'libs/moment.js/%s/%s') % (version, js_filename)
                     h_64 = _moment._sri_hash(_moment._get_data(
                         '%s' % path))
-                    js = '<script src="%s" integrity="%s" crossorigin="anonymous"></script>\n' % (path, h_64)
+                    js = ('<script src="%s" integrity="%s" ' +
+                          'crossorigin="anonymous"></script>\n') % (path, h_64)
                 else:
-                    js = '<script src="//cdnjs.cloudflare.com/ajax/libs/' \
-                         'moment.js/%s/%s"></script>\n' % (version, js_filename)
+                    js = ('<script src="//cdnjs.cloudflare.com/ajax/libs/' +
+                          'moment.js/%s/%s"></script>\n') \
+                         % (version, js_filename)
         return Markup('''%s<script>
 moment.locale("en");
 function flask_moment_render(elem) {
@@ -56,7 +58,8 @@ $(document).ready(function() {
             if sri:
                 path = 'https://code.jquery.com/jquery-%s.min.js' % version
                 h_64 = _moment._sri_hash(_moment._get_data(path))
-                js = '<script src="%s" integrity="%s" crossorigin="anonymous"></script>' % (path, h_64)
+                js = ('<script src="%s" integrity="%s" ' +
+                      'crossorigin="anonymous"></script>') % (path, h_64)
             else:
                 js = ('<script src="//code.jquery.com/' +
                       'jquery-%s.min.js"></script>') % version
@@ -78,14 +81,12 @@ $(document).ready(function() {
         return _moment.locale(language)
 
     @staticmethod
-    @lru_cache()
     def _sri_hash(data):
         h = hashlib.sha384(data).digest()
         h_64 = base64.b64encode(h).decode()
         return 'sha384-{}'.format(h_64)
 
     @staticmethod
-    @lru_cache()
     def _get_data(url):
         response = urllib.request.urlopen(url)
         data = response.read()

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -24,7 +24,7 @@ class _moment(object):
                     path = '//cdnjs.cloudflare.com/ajax/libs/moment.js/%s/%s' % (version, js_filename)
                     h_64 = _moment._sri_hash(_moment._get_data(
                         'https:%s' % path))
-                    js = '<script src="%s" integrity="%s" crossorigin="anonymous"></script>\n' % (path, h_64)
+                    js = '<script src="https://%s" integrity="%s" crossorigin="anonymous"></script>\n' % (path, h_64)
                 else:
                     js = '<script src="//cdnjs.cloudflare.com/ajax/libs/' \
                          'moment.js/%s/%s"></script>\n' % (version, js_filename)

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -80,7 +80,6 @@ $(document).ready(function() {
     @staticmethod
     @lru_cache()
     def _sri_hash(data):
-        print("Hashing..")
         h = hashlib.sha384(data).digest()
         h_64 = base64.b64encode(h).decode()
         return 'sha384-{}'.format(h_64)

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -21,9 +21,9 @@ class _moment(object):
                     if StrictVersion(version) >= StrictVersion('2.8.0') \
                     else 'moment-with-langs.min.js'
                 if sri:
-                    path = '//cdnjs.cloudflare.com/ajax/libs/moment.js/%s/%s' % (version, js_filename)
+                    path = 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/%s/%s' % (version, js_filename)
                     h_64 = _moment._sri_hash(_moment._get_data(
-                        'https:%s' % path))
+                        '%s' % path))
                     js = '<script src="%s" integrity="%s" crossorigin="anonymous"></script>\n' % (path, h_64)
                 else:
                     js = '<script src="//cdnjs.cloudflare.com/ajax/libs/' \
@@ -54,9 +54,9 @@ $(document).ready(function() {
             js = '<script src="%s"></script>\n' % local_js
         else:
             if sri:
-                h_64 = _moment._sri_hash(_moment._get_data('https://code.jquery.com/jquery-%s.min.js' % version))
-                js = ('<script src="//code.jquery.com/' +
-                      'jquery-%s.min.js" integrity="%s" crossorigin="anonymous"></script>') % (version, h_64)
+                path = 'https://code.jquery.com/jquery-%s.min.js' % version
+                h_64 = _moment._sri_hash(_moment._get_data(path))
+                js = '<script src="%s" integrity="%s" crossorigin="anonymous"></script>' % (path, h_64)
             else:
                 js = ('<script src="//code.jquery.com/' +
                       'jquery-%s.min.js"></script>') % version

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -4,7 +4,10 @@ from jinja2 import Markup
 from flask import current_app
 import hashlib
 import base64
-import urllib.request
+try:
+    import urllib.request as request
+except ImportError:
+    import urllib as request
 
 
 class _moment(object):
@@ -88,7 +91,7 @@ $(document).ready(function() {
 
     @staticmethod
     def _get_data(url):
-        response = urllib.request.urlopen(url)
+        response = request.urlopen(url)
         data = response.read()
         return data
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
 import pytest
-import os, sys
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
 from flask import Flask
 from flask_moment import Moment
 import datetime

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+import os, sys
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
 from flask import Flask
 from flask_moment import Moment
 import datetime

--- a/tests/test_flask_moment.py
+++ b/tests/test_flask_moment.py
@@ -149,7 +149,7 @@ class TestPrivateMomentClass(object):
         assert isinstance(rts, Markup)
         assert rts.find("thisisnotinthemarkup") < 0
         assert rts.find("\"format\"") > 0
-        assert rts.find("data-refresh=\"" + str(int(refresh) * 60000) + "\"") > 0
+        assert rts.find("data-refresh=\"" + str(int(refresh)*60000) + "\"") > 0
 
     def test__render_refresh(self):
         mom = _moment_mock()
@@ -159,7 +159,7 @@ class TestPrivateMomentClass(object):
         assert isinstance(rts, Markup)
         assert not rts.find("thisisnotinthemarkup") > 0
         assert rts.find("\"format\"") > 0
-        assert rts.find("data-refresh=\"" + str(int(refresh) * 60000) + "\"") > 0
+        assert rts.find("data-refresh=\"" + str(int(refresh)*60000) + "\"") > 0
 
     def test_format_default(self):
         mom = _moment_mock()
@@ -243,9 +243,10 @@ class TestPublicMomentClass(object):
 class TestSriHashGenerator(object):
 
     def test_something(self):
-        '''test with jquery v.2.1.0 and compare generated hash with https://www.srihash.org'''
+        '''test with jquery v.2.1.0 and compare generated hash'''
         url = 'https://code.jquery.com/jquery-2.1.0.min.js'
-        reference = 'sha384-85/BFduEdDxQ86xztyNu4BBkVZmlvu+iB7zhBu0VoYdq+ODs3PKpU6iVE3ZqPMut'
+        reference = ('sha384-85/BFduEdDxQ86xztyNu4BBkVZmlvu+' +
+                     'iB7zhBu0VoYdq+ODs3PKpU6iVE3ZqPMut')
         h = _moment._sri_hash(_moment._get_data(url))
         assert h == reference
 

--- a/tests/test_flask_moment.py
+++ b/tests/test_flask_moment.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-
 from flask import render_template_string
 from flask_moment import _moment, Moment
 from jinja2 import Markup
@@ -261,3 +260,20 @@ class TestSriHashGenerator(object):
 
         assert 'integrity="sha384' in js
         assert 'crossorigin="anonymous"' in js
+
+    def test_sri_hash_cache(self):
+        from flask_moment import _cache
+
+        _cache.clear()
+
+        assert len(_cache.items()) == 0
+
+        js = _moment.include_moment(sri=True)
+        assert 'integrity="sha384' in js
+        assert len(_cache.items()) == 1
+
+        js = _moment.include_jquery(sri=True)
+        assert len(_cache.items()) == 2
+
+        js = _moment.include_moment(sri=True)
+        assert len(_cache.items()) == 2

--- a/tests/test_flask_moment.py
+++ b/tests/test_flask_moment.py
@@ -9,6 +9,7 @@ from jinja2 import Markup
 
 class NewDate(datetime):
     """http://stackoverflow.com/questions/4481954"""
+
     @classmethod
     def utcnow(cls):
         return cls(2017, 1, 15, 22, 1, 21, 101361)
@@ -19,6 +20,7 @@ _datetime_mock = NewDate
 
 class NewPrivateMoment(_moment):
     """Mock the _moment class for predictable now timestamps"""
+
     def __init__(self, timestamp=None, local=False):
         if timestamp is None:
             timestamp = _datetime_mock.utcnow()
@@ -31,6 +33,7 @@ _moment_mock = NewPrivateMoment
 
 class NewPublicMoment(Moment):
     """Mock the Moment class for predictable now timestamps"""
+
     def init_app(self, app):
         if not hasattr(app, 'extensions'):
             app.extensions = {}
@@ -50,7 +53,7 @@ class TestFlaskAppSetup(object):
 
     def test_app_context_processor(self, app, moment):
         assert app.template_context_processors[None][1].__globals__[
-            '__name__'] == 'flask_moment'
+                   '__name__'] == 'flask_moment'
 
 
 class TestFlaskMomentIncludes(object):
@@ -146,7 +149,7 @@ class TestPrivateMomentClass(object):
         assert isinstance(rts, Markup)
         assert rts.find("thisisnotinthemarkup") < 0
         assert rts.find("\"format\"") > 0
-        assert rts.find("data-refresh=\""+str(int(refresh)*60000)+"\"") > 0
+        assert rts.find("data-refresh=\"" + str(int(refresh) * 60000) + "\"") > 0
 
     def test__render_refresh(self):
         mom = _moment_mock()
@@ -156,7 +159,7 @@ class TestPrivateMomentClass(object):
         assert isinstance(rts, Markup)
         assert not rts.find("thisisnotinthemarkup") > 0
         assert rts.find("\"format\"") > 0
-        assert rts.find("data-refresh=\""+str(int(refresh)*60000)+"\"") > 0
+        assert rts.find("data-refresh=\"" + str(int(refresh) * 60000) + "\"") > 0
 
     def test_format_default(self):
         mom = _moment_mock()
@@ -221,6 +224,7 @@ class TestPrivateMomentClass(object):
 
 class TestPublicMomentClass(object):
     '''Public refers to the Moment class'''
+
     def test_create_default_no_timestamp(self, app):
         moment = _Moment()
         moment.init_app(app)
@@ -234,3 +238,25 @@ class TestPublicMomentClass(object):
         ts = datetime(2017, 1, 15, 22, 47, 6, 479898)
 
         assert moment.create(timestamp=ts).timestamp == ts
+
+
+class TestSriHashGenerator(object):
+
+    def test_something(self):
+        '''test with jquery v.2.1.0 and compare generated hash with https://www.srihash.org'''
+        url = 'https://code.jquery.com/jquery-2.1.0.min.js'
+        reference = 'sha384-85/BFduEdDxQ86xztyNu4BBkVZmlvu+iB7zhBu0VoYdq+ODs3PKpU6iVE3ZqPMut'
+        h = _moment._sri_hash(_moment._get_data(url))
+        assert h == reference
+
+    def test_sri_for_jquery(self):
+        js = _moment.include_jquery(sri=True)
+
+        assert 'integrity="sha384' in js
+        assert 'crossorigin="anonymous"' in js
+
+    def test_sri_for_momentjs(self):
+        js = _moment.include_moment(sri=True)
+
+        assert 'integrity="sha384' in js
+        assert 'crossorigin="anonymous"' in js


### PR DESCRIPTION
I added the possibility to set `sri=True` when calling `include_moment()` and `include_jquery()`.

For that I added two private static methods to _moment:

`_sri_hash(data)`: Generates the sha384 hash and encodes it with base64

`_get_data(url)`: Fetches the script from the specified url in order to generate the hash.

Both methods only use standard python libraries so there should be any compatibility issues.

Also `sri` is set to False as default, so there shouldn't be any backwards compatibility issues. 

