### PR TITLE
Eliminate eval, convert to vanilla js

### DIFF
--- a/flask_moment.py
+++ b/flask_moment.py
@@ -50,12 +50,10 @@ let lambdas = {
     'fromNow': el => moment(el.dataset.timestamp).fromNow(Number(el.dataset.nosuffix))
 }
 function flask_moment_render(el) {
-    if (el.dataset.format in lambdas) {
-        console.log(Boolean(el.dataset.nosuffix));
+    if (el.dataset.format in lambdas)
         el.textContent = lambdas[el.dataset.format](el);
-    } else {
+    else
         el.textContent = moment(el.dataset.timestamp)[el.dataset.format]();
-        }
     el.classList.remove('flask-moment');
     el.style.display = '';
 }

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -121,14 +121,16 @@ document.addEventListener('DOMContentLoaded', flask_moment_render_all)
 
     def _render(self, format, refresh=False, **kwargs):
         t = self._timestamp_as_iso_8601(self.timestamp)
-        opener = (f'<span class="flask-moment" data-timestamp="{t}" '
-                  f'data-format="{format}" '
-                  f'data-refresh="{int(refresh) * 60000}" '
-                  f'style="display: none"')
+        opener = ''.join(
+            ['<span class="flask-moment" data-timestamp="%s" ' % t,
+             'data-format="%s" ' % format,
+             'data-refresh="%d" ' % (int(refresh) * 60000),
+             'style="display: none"'
+             ])
         strlist = [opener]
         for key, val in kwargs.items():
-            strlist.append(f' data-{key}="{val}"')
-        strlist.append(f'>{t}</span>')
+            strlist.append(' data-%s="%s"' % (key, val))
+        strlist.append('>%s</span>' % t)
         return Markup(''.join(strlist))
 
     def format(self, fmt, refresh=False):

--- a/tests/test_flask_moment.py
+++ b/tests/test_flask_moment.py
@@ -176,14 +176,16 @@ class TestPrivateMomentClass(object):
         no_suffix = False
         rts = mom.fromNow()
 
-        assert rts.find("fromNow(%s)" % int(no_suffix)) > 0
+        assert rts.find("data-format=\"fromNow\"") > 0
+        assert rts.find("data-nosuffix=\"0\"") > 0
 
     def test_fromNow_no_suffix(self):
         mom = _moment_mock()
         no_suffix = True
         rts = mom.fromNow(no_suffix=no_suffix)
 
-        assert rts.find("fromNow(%s)" % int(no_suffix)) > 0
+        assert rts.find("data-format=\"fromNow\"") > 0
+        assert rts.find("data-nosuffix=\"1\"") > 0
 
     def test_fromTime_default(self):
         mom = _moment_mock()
@@ -191,10 +193,10 @@ class TestPrivateMomentClass(object):
         no_suffix = False
         rts = mom.fromTime(timestamp=ts)
 
-        assert rts.find("from(moment('%s'),%s)"
-                        % (mom._timestamp_as_iso_8601(ts), int(no_suffix))) > 0
-        assert rts.find("%s" % mom._timestamp_as_iso_8601(
-            timestamp=mom.timestamp)) > 0
+        assert rts.find("data-format=\"from\"") > 0
+        assert rts.find(f"data-fromtime=\"{mom._timestamp_as_iso_8601(ts)}\"") > 0
+        assert rts.find("data-nosuffix=\"0\"") > 0
+
 
     def test_fromTime_no_suffix(self):
         mom = _moment_mock()
@@ -202,28 +204,27 @@ class TestPrivateMomentClass(object):
         no_suffix = True
         rts = mom.fromTime(timestamp=ts, no_suffix=no_suffix)
 
-        assert rts.find("from(moment('%s'),%s)"
-                        % (mom._timestamp_as_iso_8601(ts), int(no_suffix))) > 0
-        assert rts.find("%s" % mom._timestamp_as_iso_8601(
-            timestamp=mom.timestamp)) > 0
+        assert rts.find("data-format=\"from\"") > 0
+        assert rts.find(f"data-fromtime=\"{mom._timestamp_as_iso_8601(ts)}\"") > 0
+        assert rts.find("data-nosuffix=\"1\"") > 0
 
     def test_calendar_default(self):
         mom = _moment_mock()
         rts = mom.calendar()
 
-        assert rts.find("data-format=\"calendar()\"") > 0
+        assert rts.find("data-format=\"calendar\"") > 0
 
     def test_valueOf_default(self):
         mom = _moment_mock()
         rts = mom.valueOf()
 
-        assert rts.find("data-format=\"valueOf()\"") > 0
+        assert rts.find("data-format=\"valueOf\"") > 0
 
     def test_unix_default(self):
         mom = _moment_mock()
         rts = mom.unix()
 
-        assert rts.find("data-format=\"unix()\"") > 0
+        assert rts.find("data-format=\"unix\"") > 0
 
 
 class TestPublicMomentClass(object):


### PR DESCRIPTION
So for this conversion (regarding eval) I discovered that it was mostly a lot easier than I expected (after initially believing it would be a lot harder than I expected).

The primary problem presented in this case is regarding the parameters called to the moment. This is why the fromNow exists.

I thought just a minute ago about how it would be possible to, instead of rendering each parameter as a dataset attribute, simply render a csv string of the parameters and then split on the commas. This becomes more complicated as we start dealing with datatypes (string vs bool vs int, etc.) but I think I could manage it.

The one point at which I *don't think I could manage it anymore* is with regard to `from` as we need to create a new `moment`.

It would theoretically be possible to write a `getArgs()` function that took a type-annotated csv string, e.g. `moment:<timestamp>,int:<int>` which would then parse those into the correct datatypes. Heck, I could just use JSON I would think, but at that point we're really writing a parser.

Wow I just noticed I still have a console logger there and a random return. Sorry will clean immediately.

As regards elimination of JQuery, I think this did it.

Opinions?