### PR TITLE
Rewrite vanilla js

### DIFF
--- a/flask_moment.py
+++ b/flask_moment.py
@@ -45,20 +45,19 @@ class _moment(object):
         return Markup('''%s<script>
 moment.locale("en");
 function flask_moment_render(elem) {
-    $(elem).text(eval('moment("' + $(elem).data('timestamp') + '").' + $(elem).data('format') + ';'));
-    $(elem).removeClass('flask-moment').show();
+    elem.textContent = eval('moment("' + elem.dataset.timestamp + '").' + elem.dataset.format + ';');
+    elem.classList.remove('flask-moment');
+    elem.style.display = '';
 }
 function flask_moment_render_all() {
-    $('.flask-moment').each(function() {
-        flask_moment_render(this);
-        if ($(this).data('refresh')) {
-            (function(elem, interval) { setInterval(function() { flask_moment_render(elem) }, interval); })(this, $(this).data('refresh'));
-        }
-    })
+    [...document.getElementsByClassName('flask-moment')].forEach(
+        elem => {
+            flask_moment_render(elem);
+            if (elem.dataset.refresh != 0)
+                setInterval(() => flask_moment_render(elem), elem.dataset.refresh);
+        });
 }
-$(document).ready(function() {
-    flask_moment_render_all();
-});
+document.addEventListener('DOMContentLoaded', flask_moment_render_all);
 </script>''' % js)  # noqa: E501
 
     @staticmethod


### PR DESCRIPTION
I have rewritten the primary script as vanilla js.

This means one can (and I have tested it) eliminate the `include_jquery()` tag inside the jinja2 template where moment is used.

I have done nothing to change the `include_jquery()` tag because that would produce breaking changes for anyone relying on Flask-Moment's jquery inclusion tag.

I have also not introduced the nonce attribute I mentioned I would like to add. I feel it is a separate matter.

If any of this JavaScript is not to your stylistic liking, please let me know.