### PR TITLE
Set a default format

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ The supported list of display functions is shown below:
 
 Consult the [moment.js documentation](http://momentjs.com/) for details on these functions.
 
+Default Format
+--------------
+
+If you most or all of your timestamps use the same format you can use the Flask config API to pass the option __MOMENT_DEFAULT_FORMAT__ = 'format_string'. To use the default format use with {{ moment(timestamp).default() }}. Consult the [moment.js format documentation](http://momentjs.com/docs/#/displaying/format/) for a list of acepted tokens.
+
 Auto-Refresh
 ------------
 

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -120,7 +120,8 @@ $(document).ready(function() {
                       (t, format, int(refresh) * 60000, t))
 
     def default(self, refresh=False):
-        return self.format(current_app.config['MOMENT_DEFAULT_FORMAT'], refresh)
+        fmt = current_app.config['MOMENT_DEFAULT_FORMAT']
+        return self.format(fmt, refresh)
 
     def format(self, fmt, refresh=False):
         return self._render("format('%s')" % fmt, refresh)

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -118,7 +118,7 @@ $(document).ready(function() {
                        'data-format="%s" data-refresh="%d" ' +
                        'style="display: none">%s</span>') %
                       (t, format, int(refresh) * 60000, t))
-    
+
     def default(self):
         return self.format(current_app.config['MOMENT_DEFAULT_FORMAT'])
 

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -112,12 +112,15 @@ $(document).ready(function() {
             tz = 'Z'
         return timestamp.strftime('%Y-%m-%dT%H:%M:%S' + tz)
 
-    def _render(self, format, refresh=False):
+    def _render(self, format, refresh=False):                                          
         t = self._timestamp_as_iso_8601(self.timestamp)
         return Markup(('<span class="flask-moment" data-timestamp="%s" ' +
                        'data-format="%s" data-refresh="%d" ' +
                        'style="display: none">%s</span>') %
                       (t, format, int(refresh) * 60000, t))
+    
+    def default(self):
+        return self.format(current_app.config['MOMENT_DEFAULT_FORMAT'])
 
     def format(self, fmt, refresh=False):
         return self._render("format('%s')" % fmt, refresh)

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -119,8 +119,8 @@ $(document).ready(function() {
                        'style="display: none">%s</span>') %
                       (t, format, int(refresh) * 60000, t))
 
-    def default(self):
-        return self.format(current_app.config['MOMENT_DEFAULT_FORMAT'])
+    def default(self, refresh=False):
+        return self.format(current_app.config['MOMENT_DEFAULT_FORMAT'], refresh)
 
     def format(self, fmt, refresh=False):
         return self._render("format('%s')" % fmt, refresh)

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -112,7 +112,7 @@ $(document).ready(function() {
             tz = 'Z'
         return timestamp.strftime('%Y-%m-%dT%H:%M:%S' + tz)
 
-    def _render(self, format, refresh=False):                                          
+    def _render(self, format, refresh=False):
         t = self._timestamp_as_iso_8601(self.timestamp)
         return Markup(('<span class="flask-moment" data-timestamp="%s" ' +
                        'data-format="%s" data-refresh="%d" ' +

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name='Flask-Moment',
-    version='0.7.0',
+    version='0.7.1',
     url='http://github.com/miguelgrinberg/flask-moment/',
     license='MIT',
     author='Miguel Grinberg',


### PR DESCRIPTION
I found in using this in my app I use the same string format in all my web pages. When adding new dates in new pages I would have a hard time remembering what exactly that format was. This solves that problem by setting a config variable to the format needed without needing to register a new jinja variable.