### PR TITLE
Setting a default format 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The supported list of display functions is shown below:
 - `moment(timestamp=None, local=False).calendar()`
 - `moment(timestamp=None, local=False).valueOf()`
 - `moment(timestamp=None, local=False).unix()`
+- `moment(timestamp=None, local=False).default()`
 
 Consult the [moment.js documentation](http://momentjs.com/) for details on these functions.
 
@@ -68,6 +69,11 @@ Auto-Refresh
 ------------
 
 All the display functions take an optional `refresh` argument that when set to `True` will re-render timestamps every minute. This can be useful for relative time formats such as the one returned by the `fromNow()` or `fromTime()` functions. By default refreshing is disabled.
+
+Default Format
+--------------
+
+If you most or all of your timestamps use the same format you can use the Flask config API to pass the option __MOMENT_DEFAULT_FORMAT__ = 'format_string'. To use the default format use with {{ moment(timestamp).default() }}. Consult the [moment.js format documentation](http://momentjs.com/docs/#/displaying/format/) for a list of acepted tokens.
 
 Internationalization
 --------------------

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -119,6 +119,10 @@ $(document).ready(function() {
                        'style="display: none">%s</span>') %
                       (t, format, int(refresh) * 60000, t))
 
+    def default(self, refresh=False):
+        fmt = current_app.config['MOMENT_DEFAULT_FORMAT']
+        return self.format(fmt, refresh)
+
     def format(self, fmt, refresh=False):
         return self._render("format('%s')" % fmt, refresh)
 


### PR DESCRIPTION
I found in using this in my app I use the same string format in all my web pages. When adding new dates in new pages I would have a hard time remembering what exactly that format was. This solves that problem by setting a config variable to the format needed without needing to register a new jinja variable.