### PR TITLE
Add support of customization object for the method "moment.locale(...)".

### DIFF
--- a/flask_moment.py
+++ b/flask_moment.py
@@ -90,15 +90,17 @@ $(document).ready(function() {
         return Markup(js)
 
     @staticmethod
-    def locale(language='en', auto_detect=False):
+    def locale(language='en', auto_detect=False, customization=None):
         if auto_detect:
             return Markup('<script>\nvar locale = '
                           'window.navigator.userLanguage || '
                           'window.navigator.language;\n'
                           'moment.locale(locale);\n</script>')
-        else:
+        if customization:
             return Markup(
-                '<script>\nmoment.locale("%s");\n</script>' % language)
+                '<script>\nmoment.locale("%s", %s);\n</script>' % (language, customization))
+        return Markup(
+            '<script>\nmoment.locale("%s");\n</script>' % language)
 
     @staticmethod
     def lang(language):

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -98,7 +98,8 @@ $(document).ready(function() {
                           'moment.locale(locale);\n</script>')
         if customization:
             return Markup(
-                '<script>\nmoment.locale("%s", %s);\n</script>' % (language, customization))
+                '<script>\nmoment.locale("%s", %s);\n</script>' % (
+                    language, customization))
         return Markup(
             '<script>\nmoment.locale("%s");\n</script>' % language)
 


### PR DESCRIPTION
Moment.js allows customization of locale by dictionary-object
(docs: https://momentjs.com/docs/#/i18n/changing-locale/ )


Example:
````   
    @bp.before_app_request
    def before_request():
        g.locale = "eo"
        g.locale_customization = {
            "longDateFormat": {
                "L": "DD.MM.YYYY",
                "LLL": "DD.MM.YYYY hh:mm",
            },
        }
````
````
    {% block scripts %}
        {{ moment.include_jquery() }}
        {{ moment.include_moment() }}
        {{ moment.locale(g.locale, customization=g.locale_customization) }}
    {% endblock %}
````

It should render:
````
	<script>
	    moment.locale('eo', {
                    'longDateFormat': {
                        'L': 'DD.MM.YYYY',
                        'LLL': 'DD.MM.YYYY hh:mm'
                    }
                }
            );
	</script>
````