### PR TITLE
add methods for moment.js subtract, add, diff

### DIFF
--- a/flask_moment.py
+++ b/flask_moment.py
@@ -130,6 +130,15 @@ $(document).ready(function() {
                             (self._timestamp_as_iso_8601(timestamp),
                              int(no_suffix)), refresh)
 
+    def subtract(self, param, date_format):
+        return self._render("subtract(%s).format('%s')" % (param, date_format))
+
+    def add(self, param, date_format):
+        return self._render("add(%s).format('%s')" % (param, date_format))
+
+    def diff(self, timestamp, param):
+        return self._render("diff(%s, '%s')" % (timestamp, param))
+
     def calendar(self, refresh=False):
         return self._render("calendar()", refresh)
 

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -137,7 +137,7 @@ $(document).ready(function() {
         return self._render("add(%s).format('%s')" % (param, date_format))
 
     def diff(self, timestamp, param):
-        return self._render("diff(%s, '%s')" % (timestamp, param))
+        return self._render("diff('%s', '%s')" % (timestamp, param))
 
     def calendar(self, refresh=False):
         return self._render("calendar()", refresh)


### PR DESCRIPTION
Had trouble with adding .format() to the end of subtract, and add because of render statements being parsed in-between. For this reason these methods expect a format parameter which will be added to the aforementioned moment.js render call.

Issue #35 