### PR TITLE
Add toTime and toNow to display functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The supported list of display functions is shown below:
 - `moment(timestamp=None, local=False).format(format_string=None)`
 - `moment(timestamp=None, local=False).fromNow(no_suffix=False)`
 - `moment(timestamp=None, local=False).fromTime(another_timesatmp, no_suffix=False)`
+- `moment(timestamp=None, local=False).toNow(no_suffix=False)`
+- `moment(timestamp=None, local=False).toTime(another_timesatmp, no_suffix=False)`
 - `moment(timestamp=None, local=False).calendar()`
 - `moment(timestamp=None, local=False).valueOf()`
 - `moment(timestamp=None, local=False).unix()`

--- a/example/app.py
+++ b/example/app.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from flask import Flask, render_template, jsonify
 from flask_moment import Moment
 
@@ -11,8 +11,9 @@ def index():
     now = datetime.utcnow()
     midnight = datetime(now.year, now.month, now.day, 0, 0, 0)
     epoch = datetime(1970, 1, 1, 0, 0, 0)
+    next_saturday = now + timedelta(5 - now.weekday())
     return render_template('index.html', now=now, midnight=midnight,
-                           epoch=epoch)
+                           epoch=epoch, next_saturday=next_saturday)
 
 
 @app.route('/ajax')

--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -20,6 +20,7 @@
         <p>
             {{ moment(midnight).fromTime(now) }} it was midnight in the UTC timezone. 
             That was {{ moment(midnight).calendar() }} in your local time.
+            It will be midnight again {{ moment(midnight).toNow() }}.
         </p>
         <p>
             Unix epoch is {{ moment(epoch, local=True).format('LLLL') }} in the UTC timezone.
@@ -28,6 +29,9 @@
         <p>
             This page was rendered on {{ moment(now).format('LLL') }},
             which was {{ moment(now).fromNow(refresh = True) }}.
+        </p>
+        <p>
+            The next Saturday will be in {{ moment(now).toTime(next_saturday) }}, from the time this page was rendered.
         </p>
         <div id="ajax"></div>
         <a href="#" onclick="load_ajax_timestamp()">Load Ajax timestamp</a>

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -137,6 +137,14 @@ $(document).ready(function() {
                             (self._timestamp_as_iso_8601(timestamp),
                              int(no_suffix)), refresh)
 
+    def toNow(self, no_suffix=False, refresh=False):
+        return self._render("toNow(%s)" % int(no_suffix), refresh)
+
+    def toTime(self, timestamp, no_suffix=False, refresh=False):
+        return self._render("to(moment('%s'),%s)" %
+                            (self._timestamp_as_iso_8601(timestamp),
+                             int(no_suffix)), refresh)
+
     def calendar(self, refresh=False):
         return self._render("calendar()", refresh)
 

--- a/tests/test_flask_moment.py
+++ b/tests/test_flask_moment.py
@@ -214,6 +214,42 @@ class TestPrivateMomentClass(object):
         assert rts.find("%s" % mom._timestamp_as_iso_8601(
             timestamp=mom.timestamp)) > 0
 
+    def test_toNow_default(self):
+        mom = _moment_mock()
+        no_suffix = False
+        rts = mom.toNow()
+
+        assert rts.find("toNow(%s)" % int(no_suffix)) > 0
+
+    def test_toNow_no_suffix(self):
+        mom = _moment_mock()
+        no_suffix = True
+        rts = mom.toNow(no_suffix=no_suffix)
+
+        assert rts.find("toNow(%s)" % int(no_suffix)) > 0
+
+    def test_toTime_default(self):
+        mom = _moment_mock()
+        ts = datetime(2020, 1, 15, 22, 47, 6, 479898)
+        no_suffix = False
+        rts = mom.toTime(timestamp=ts)
+
+        assert rts.find("to(moment('%s'),%s)"
+                        % (mom._timestamp_as_iso_8601(ts), int(no_suffix))) > 0
+        assert rts.find("%s" % mom._timestamp_as_iso_8601(
+            timestamp=mom.timestamp)) > 0
+
+    def test_toTime_no_suffix(self):
+        mom = _moment_mock()
+        ts = datetime(2020, 1, 15, 22, 47, 6, 479898)
+        no_suffix = True
+        rts = mom.toTime(timestamp=ts, no_suffix=no_suffix)
+
+        assert rts.find("to(moment('%s'),%s)"
+                        % (mom._timestamp_as_iso_8601(ts), int(no_suffix))) > 0
+        assert rts.find("%s" % mom._timestamp_as_iso_8601(
+            timestamp=mom.timestamp)) > 0
+
     def test_calendar_default(self):
         mom = _moment_mock()
         rts = mom.calendar()


### PR DESCRIPTION
#### Problem:
`MomentJS >= 2.10.3` supports `.to` and `.toNow` functions which give the ability to display an opposite interval to `.from` and `.fromNow`. [ MomentJS Docs
](https://momentjs.com/docs/#/displaying/tonow/)

#### Solution:
- Add `toTime` and `toNow` display functions.
- Add test coverage.
- Update `README`.
- Add functions to the example app.

Thanks so much for the awesome extension 🚀