### PR TITLE
https is always used to request the js files from the CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This extension also supports the [Flask application factory pattern](http://flas
 
         app = create_app(prod_config)
 
-Note that jQuery is required. If you are already including it on your own then you can remove the `include_jquery()` line. Secure HTTP is used if the request under which these are executed is secure.
+Note that jQuery is required. If you are already including it on your own then you can remove the `include_jquery()` line. Secure HTTP is always used to request the external js files..
 
 The `include_jquery()` and `include_moment()` methods take some optional arguments. If you pass a `version` argument to any of these two calls, then the requested version will be loaded from the default CDN. If you pass `local_js`, then the given local path will be used to load the library. The `include_moment()` argument takes a third argument `no_js` that when set to `True` will assume that the Moment JavaScript library is already loaded and will only add the JavaScript code that supports this extension.
 

--- a/flask_moment.py
+++ b/flask_moment.py
@@ -39,11 +39,11 @@ class _moment(object):
                     js_filename = 'moment.min.js'
                 
                 if not sri:
-                    js = ('<script src="//cdnjs.cloudflare.com/ajax/libs/'
+                    js = ('<script src="https://cdnjs.cloudflare.com/ajax/libs/'
                           'moment.js/{}/{}"></script>\n').format(
                               version, js_filename)
                 else:
-                    js = ('<script src="//cdnjs.cloudflare.com/ajax/libs/'
+                    js = ('<script src="https://cdnjs.cloudflare.com/ajax/libs/'
                           'moment.js/{}/{}" integrity="{}" '
                           'crossorigin="anonymous"></script>\n').format(
                               version, js_filename, sri)
@@ -100,10 +100,10 @@ $(document).ready(function() {{
 
         else:
             if not sri:
-                js = ('<script src="//code.jquery.com/' +
+                js = ('<script src="https://code.jquery.com/' +
                       'jquery-{}.min.js"></script>').format(version)
             else:
-                js = ('<script src="//code.jquery.com/jquery-{}.min.js" '
+                js = ('<script src="https://code.jquery.com/jquery-{}.min.js" '
                       'integrity="{}" crossorigin="anonymous">'
                       '</script>').format(version, sri)
         return Markup(js)

--- a/tests/test_flask_moment.py
+++ b/tests/test_flask_moment.py
@@ -301,7 +301,7 @@ class TestSubresourceIntegrity(object):
         include_jquery = _moment.include_jquery(version='2.1.1',
                                                 sri='sha384-12345678')
 
-        assert ('<script src=\"//code.jquery.com/jquery-2.1.1.min.js\"'
+        assert ('<script src=\"https://code.jquery.com/jquery-2.1.1.min.js\"'
                 ' integrity=\"sha384-12345678\" crossorigin=\"anonymous\">'
                 '</script>') == include_jquery
 
@@ -361,7 +361,7 @@ class TestSubresourceIntegrity(object):
         include_moment = _moment.include_moment()
 
         assert include_moment.startswith(
-            '<script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/{}'
+            '<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/{}'
             '/moment-with-locales.min.js" integrity="{}" '
             'crossorigin="anonymous"></script>'.format(
                 default_moment_version, default_moment_sri))
@@ -370,7 +370,7 @@ class TestSubresourceIntegrity(object):
         include_moment = _moment.include_moment(sri='sha384-12345678')
 
         assert include_moment.startswith(
-            '<script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/{}'
+            '<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/{}'
             '/moment-with-locales.min.js" integrity="sha384-12345678" '
             'crossorigin="anonymous"></script>'.format(default_moment_version))
 
@@ -378,7 +378,7 @@ class TestSubresourceIntegrity(object):
                                                 sri='sha384-12345678')
 
         assert include_moment.startswith(
-            '<script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.0.0'
+            '<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.0.0'
             '/moment-with-langs.min.js" integrity="sha384-12345678" '
             'crossorigin="anonymous"></script>')
 


### PR DESCRIPTION
I've added a small change to ensure that the js files are requested over https.

To implement this change, I've updated:

- flask_moment.py
- test_flask_moment.py
- README.md

I've run the tests and they're all passing.
This is in relation to issue #64 