### PR TITLE
Import Markup from markupsafe (future deprecation)

### DIFF
--- a/flask_moment.py
+++ b/flask_moment.py
@@ -1,6 +1,6 @@
 from distutils.version import StrictVersion
 from datetime import datetime
-from jinja2 import Markup
+from markupsafe import Markup
 from flask import current_app
 
 # //code.jquery.com/jquery-3.5.1.min.js


### PR DESCRIPTION
Noticed this while testing the current flask2 rc suite. Note there's a bug in the current rc preventing `jinja2.Markup` from working. A fix has been committed already.

Instead, `Markup` should be imported from `markupsafe`. I checked and this has been possible for many years now (jinja 2.9.x branch from 2y ago imports from here already).

Note jinja 3.0.0 will emit a deprecation warning, with removal in 3.1, so a whiles away for sure. Nonetheless, it should be a backwards-compatible change, so there shouldn't be any issue changing it now.