### PR TITLE
fix Markup type tests

### DIFF
--- a/tests/test_flask_moment.py
+++ b/tests/test_flask_moment.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from flask import render_template_string
-from jinja2 import Markup
+from markupsafe import Markup
 from flask_moment import _moment, Moment, default_jquery_version, \
     default_moment_version, default_moment_sri
 


### PR DESCRIPTION
hi

context
- related to latest change https://github.com/miguelgrinberg/Flask-Moment/pull/71 
- tests like below fail when use `Jinja2==3.0.0`
```python
assert isinstance(include_moment, Markup)
```
