### PR TITLE
add diff(), add(), subtract() functions support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
       env: TOXENV=py37
     - python: 3.8
       env: TOXENV=py38
+    - python: 3.9
+        env: TOXENV=py39
     - python: pypy
       env: TOXENV=pypy
     - python: pypy3

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ The supported list of display functions is shown below:
 - `moment(timestamp=None, local=False).calendar()`
 - `moment(timestamp=None, local=False).valueOf()`
 - `moment(timestamp=None, local=False).unix()`
+- `moment(timestamp=None, local=False).diff(another_timesatmp, units=None, as_float=False)`
+- `moment(timestamp=None, local=False).add(self, value, units, as_float=False, format=None)`
+- `moment(timestamp=None, local=False).subtract(self, value, units, as_float=False, format=None)`
 
 Consult the [moment.js documentation](http://momentjs.com/) for details on these functions.
 

--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -33,6 +33,16 @@
         <p>
             The next Saturday will be in {{ moment(now).toTime(next_saturday) }}, from the time this page was rendered.
         </p>
+        <p>
+            The next Saturday and Now diff: {{ moment(next_saturday).diff(now, 'days') }} days
+            or {{ moment(next_saturday).diff(now, 'hours') }} hours.
+        </p>
+        <p>
+            One week past Now: {{ moment().add(1, 'weeks', format='LLL') }}.
+        </p>
+        <p>
+            One week before Now: {{ moment().subtract(1, 'weeks', format='LLL') }}.
+        </p>
         <div id="ajax"></div>
         <a href="#" onclick="load_ajax_timestamp()">Load Ajax timestamp</a>
     </body>

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=flake8,py27,py35,py36,py37,py38,pypy,pypy3
+envlist=flake8,py27,py35,py36,py37,py38,py39,pypy,pypy3
 skip_missing_interpreters=true
 
 [testenv]
@@ -14,11 +14,12 @@ basepython=
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
     pypy: pypy
     pypy3: pypy3
 
 [testenv:flake8]
-basepython=python3.8
+basepython=python3.9
 commands=
     flake8 flask_moment.py tests example
 deps=


### PR DESCRIPTION
hi

### Context
- related issue https://github.com/miguelgrinberg/Flask-Moment/issues/35
- implement support for the next functions
  - https://momentjs.com/docs/#/manipulating/add/
  - https://momentjs.com/docs/#/manipulating/subtract/
  - https://momentjs.com/docs/#/displaying/difference/

### Notice
- i've extended example app to include new functions
- i've added py3.9 support for tox/ci
- i've rewritten javascript to enable format add() and subtract() results
   - we can't use moment js chaining like moment().add(1, 'days').format('L') because of one-way communication between python and js code. so we must pass `format` as parameter to functions that return raw datetime to pretty print result in templates
- i've refactored how js functions parameters are construct to reuse data keys (in html attributes `data-`)
- i've refactored tests to reference those data keys

p.s. ping me if something requires enhancement 